### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 env:
   GO_VERSION: '^1.23.5'
 


### PR DESCRIPTION
Potential fix for [https://github.com/GoCodeAlone/modular/security/code-scanning/1](https://github.com/GoCodeAlone/modular/security/code-scanning/1)

To resolve the issue, add an explicit `permissions` block to the workflow. This block should grant only the necessary permissions, adhering to the principle of least privilege. 

For this workflow:
1. The jobs primarily require access to the repository contents (`contents: read`) to run tests and upload reports.
2. Additional permissions (`pull-requests: write`) may be required if the workflow interacts with pull requests in the future.

The `permissions` key can be added at the workflow level (affecting all jobs by default) or at the job level (specific to each job). In this case, adding `permissions` at the workflow level is sufficient and avoids redundancy.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
