### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/module-release.yml
+++ b/.github/workflows/module-release.yml
@@ -1,6 +1,10 @@
 name: Module Release
 run-name: Module Release for ${{ inputs.module || github.event.inputs.module }} - ${{ inputs.releaseType || github.event.inputs.releaseType }}
-
+permissions:
+  contents: write
+  pull-requests: read
+  issues: read
+  packages: read
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/GoCodeAlone/modular/security/code-scanning/3](https://github.com/GoCodeAlone/modular/security/code-scanning/3)

To address this issue, add a `permissions` block at the root of the workflow file to explicitly set the permissions required for the workflow. Since this workflow involves creating releases and pushing tags, it will need `contents: write` permission. However, the rest of the permissions can be limited to `read`. This ensures that the workflow can execute its tasks without granting unnecessary privileges.

The `permissions` block will be added at the top level of the workflow file, just below the workflow `name` and `run-name` keys, so that it applies to all jobs in the workflow unless overridden within a specific job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
