### PR TITLE
Potential fix for code scanning alert no. 15: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/examples-ci.yml
+++ b/.github/workflows/examples-ci.yml
@@ -1,5 +1,8 @@
 name: Examples CI
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ main ]


### PR DESCRIPTION
Potential fix for [https://github.com/GoCodeAlone/modular/security/code-scanning/15](https://github.com/GoCodeAlone/modular/security/code-scanning/15)

The best way to fix the issue is to add a `permissions` block at the root of the workflow file or within each job to explicitly set the required permissions. Since the workflow does not perform any actions requiring `write` access, the permissions can be reduced to `contents: read`. This ensures that the workflow operates with the minimal permissions necessary, reducing the risk of accidental or malicious repository modifications.

Changes required:
1. Add a `permissions` block at the root of the workflow file to apply to all jobs.
2. Set `contents: read` to grant only read access to repository contents.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
