### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,10 @@
 name: Release
 run-name: Release ${{ github.event.inputs.version || github.event.inputs.releaseType }}
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/GoCodeAlone/modular/security/code-scanning/9](https://github.com/GoCodeAlone/modular/security/code-scanning/9)

To address the issue, we will add a `permissions` block at the root of the workflow file to limit the `GITHUB_TOKEN` permissions to the minimum required for the tasks performed. Based on the workflow, the following permissions are relevant:
- `contents: read`: Required for actions like checking out code and reading repository contents.
- `issues: write`: Required for interacting with issues (if applicable).
- `pull-requests: write`: Required for creating or modifying pull requests (if applicable).
- `packages: write`: Needed for announcing the Go module to the proxy.
- `actions: write`: Required for managing actions (if applicable).

Given the tasks in the workflow, the `contents: read` permission is the minimal starting point, and any additional permissions needed for specific tasks will be added.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
