### PR TITLE
docs(modular): add CHANGELOG + CONTRIBUTING (QoL sweep follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+This repository is a multi-module Go module; each sub-module under `modules/`
+has its own versioning tag (e.g. `modules/auth/v1.16.0`). The core `modular`
+package follows its own `vN.M.P` tag stream.
+
+## [Unreleased]
+### Added
+- Initial CHANGELOG + CONTRIBUTING (QoL sweep follow-up).
+
+## Recent core releases
+
+See `git tag --list 'v*' --sort=-version:refname | head` for the full list.
+
+## Recent sub-module releases
+
+See `git tag --list 'modules/*/v*' --sort=-version:refname | head -20` for
+per-module tag history.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to modular
+
+The foundation library for the [GoCodeAlone/workflow](https://github.com/GoCodeAlone/workflow) ecosystem. Used by `workflow`, `ratchet`, `ratchet-cli`, `workflow-cloud`, and many plugins.
+
+## Before contributing
+
+Read [README.md](README.md) for the module lifecycle, dependency model, and observer pattern.
+
+## Local development
+
+```sh
+git clone https://github.com/GoCodeAlone/modular.git
+cd modular
+go build ./...
+go test ./...
+```
+
+If you have a `go.work` file in a parent directory (multi-repo workspace), use:
+
+```sh
+GOWORK=off go build ./...
+GOWORK=off go test ./...
+```
+
+Sub-modules under `modules/` build independently:
+
+```sh
+cd modules/auth
+go build ./...
+go test ./...
+```
+
+## Pull requests
+
+- One feature or bugfix per PR.
+- Update CHANGELOG.md with a Keep-a-Changelog entry.
+- Add tests covering new behaviour (modular has extensive BDD coverage — match it).
+- Run `go vet ./...` before pushing.
+- For sub-module changes: bump the sub-module's tag separately from the core package.
+
+## Reporting issues
+
+See the issue templates under `.github/ISSUE_TEMPLATE/`.


### PR DESCRIPTION
Closes #109. modular is the workflow ecosystem foundation lib; missing CHANGELOG + CONTRIBUTING was a gap for external contributors. Adds both, documenting the multi-module tag stream + GOWORK=off pattern.