### PR TITLE
docs(modular): add CONTRIBUTING.md to 7 sub-modules

### DIFF
--- a/modules/auth/CONTRIBUTING.md
+++ b/modules/auth/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing to modular/auth
+
+This is a sub-module of [GoCodeAlone/modular](https://github.com/GoCodeAlone/modular) — a separately-versioned Go module under `modules/auth/`. Its tag stream is `modules/auth/vN.M.P`, independent of the core `modular` package.
+
+## Before contributing
+
+Read the top-level [CONTRIBUTING.md](../../CONTRIBUTING.md) for general conventions.
+
+## Local development
+
+Sub-module builds standalone:
+
+```sh
+cd modules/auth
+go build ./...
+go test ./...
+```
+
+If you have a `go.work` file in a parent directory (multi-repo workspace):
+
+```sh
+GOWORK=off go build ./...
+GOWORK=off go test ./...
+```
+
+## Pull requests
+
+- One feature or bugfix per PR. Keep changes scoped to this sub-module.
+- Update CHANGELOG.md (in this sub-module's directory) with a Keep-a-Changelog entry.
+- Add tests covering new behaviour — match this sub-module's existing test style.
+- Run `GOWORK=off go vet ./...` before pushing.
+- Bump the sub-module tag (`modules/auth/vN.M.P`) separately from the core `modular` tag.
+
+## Reporting issues
+
+Use the issue templates under `.github/ISSUE_TEMPLATE/` at the repo root.

--- a/modules/cache/CONTRIBUTING.md
+++ b/modules/cache/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing to modular/cache
+
+This is a sub-module of [GoCodeAlone/modular](https://github.com/GoCodeAlone/modular) — a separately-versioned Go module under `modules/cache/`. Its tag stream is `modules/cache/vN.M.P`, independent of the core `modular` package.
+
+## Before contributing
+
+Read the top-level [CONTRIBUTING.md](../../CONTRIBUTING.md) for general conventions.
+
+## Local development
+
+Sub-module builds standalone:
+
+```sh
+cd modules/cache
+go build ./...
+go test ./...
+```
+
+If you have a `go.work` file in a parent directory (multi-repo workspace):
+
+```sh
+GOWORK=off go build ./...
+GOWORK=off go test ./...
+```
+
+## Pull requests
+
+- One feature or bugfix per PR. Keep changes scoped to this sub-module.
+- Update CHANGELOG.md (in this sub-module's directory) with a Keep-a-Changelog entry.
+- Add tests covering new behaviour — match this sub-module's existing test style.
+- Run `GOWORK=off go vet ./...` before pushing.
+- Bump the sub-module tag (`modules/cache/vN.M.P`) separately from the core `modular` tag.
+
+## Reporting issues
+
+Use the issue templates under `.github/ISSUE_TEMPLATE/` at the repo root.

--- a/modules/database/CONTRIBUTING.md
+++ b/modules/database/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing to modular/database
+
+This is a sub-module of [GoCodeAlone/modular](https://github.com/GoCodeAlone/modular) — a separately-versioned Go module under `modules/database/`. Its tag stream is `modules/database/vN.M.P`, independent of the core `modular` package.
+
+## Before contributing
+
+Read the top-level [CONTRIBUTING.md](../../CONTRIBUTING.md) for general conventions.
+
+## Local development
+
+Sub-module builds standalone:
+
+```sh
+cd modules/database
+go build ./...
+go test ./...
+```
+
+If you have a `go.work` file in a parent directory (multi-repo workspace):
+
+```sh
+GOWORK=off go build ./...
+GOWORK=off go test ./...
+```
+
+## Pull requests
+
+- One feature or bugfix per PR. Keep changes scoped to this sub-module.
+- Update CHANGELOG.md (in this sub-module's directory) with a Keep-a-Changelog entry.
+- Add tests covering new behaviour — match this sub-module's existing test style.
+- Run `GOWORK=off go vet ./...` before pushing.
+- Bump the sub-module tag (`modules/database/vN.M.P`) separately from the core `modular` tag.
+
+## Reporting issues
+
+Use the issue templates under `.github/ISSUE_TEMPLATE/` at the repo root.

--- a/modules/eventbus/CONTRIBUTING.md
+++ b/modules/eventbus/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing to modular/eventbus
+
+This is a sub-module of [GoCodeAlone/modular](https://github.com/GoCodeAlone/modular) — a separately-versioned Go module under `modules/eventbus/`. Its tag stream is `modules/eventbus/vN.M.P`, independent of the core `modular` package.
+
+## Before contributing
+
+Read the top-level [CONTRIBUTING.md](../../CONTRIBUTING.md) for general conventions.
+
+## Local development
+
+Sub-module builds standalone:
+
+```sh
+cd modules/eventbus
+go build ./...
+go test ./...
+```
+
+If you have a `go.work` file in a parent directory (multi-repo workspace):
+
+```sh
+GOWORK=off go build ./...
+GOWORK=off go test ./...
+```
+
+## Pull requests
+
+- One feature or bugfix per PR. Keep changes scoped to this sub-module.
+- Update CHANGELOG.md (in this sub-module's directory) with a Keep-a-Changelog entry.
+- Add tests covering new behaviour — match this sub-module's existing test style.
+- Run `GOWORK=off go vet ./...` before pushing.
+- Bump the sub-module tag (`modules/eventbus/vN.M.P`) separately from the core `modular` tag.
+
+## Reporting issues
+
+Use the issue templates under `.github/ISSUE_TEMPLATE/` at the repo root.

--- a/modules/jsonschema/CONTRIBUTING.md
+++ b/modules/jsonschema/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing to modular/jsonschema
+
+This is a sub-module of [GoCodeAlone/modular](https://github.com/GoCodeAlone/modular) — a separately-versioned Go module under `modules/jsonschema/`. Its tag stream is `modules/jsonschema/vN.M.P`, independent of the core `modular` package.
+
+## Before contributing
+
+Read the top-level [CONTRIBUTING.md](../../CONTRIBUTING.md) for general conventions.
+
+## Local development
+
+Sub-module builds standalone:
+
+```sh
+cd modules/jsonschema
+go build ./...
+go test ./...
+```
+
+If you have a `go.work` file in a parent directory (multi-repo workspace):
+
+```sh
+GOWORK=off go build ./...
+GOWORK=off go test ./...
+```
+
+## Pull requests
+
+- One feature or bugfix per PR. Keep changes scoped to this sub-module.
+- Update CHANGELOG.md (in this sub-module's directory) with a Keep-a-Changelog entry.
+- Add tests covering new behaviour — match this sub-module's existing test style.
+- Run `GOWORK=off go vet ./...` before pushing.
+- Bump the sub-module tag (`modules/jsonschema/vN.M.P`) separately from the core `modular` tag.
+
+## Reporting issues
+
+Use the issue templates under `.github/ISSUE_TEMPLATE/` at the repo root.

--- a/modules/letsencrypt/CONTRIBUTING.md
+++ b/modules/letsencrypt/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing to modular/letsencrypt
+
+This is a sub-module of [GoCodeAlone/modular](https://github.com/GoCodeAlone/modular) — a separately-versioned Go module under `modules/letsencrypt/`. Its tag stream is `modules/letsencrypt/vN.M.P`, independent of the core `modular` package.
+
+## Before contributing
+
+Read the top-level [CONTRIBUTING.md](../../CONTRIBUTING.md) for general conventions.
+
+## Local development
+
+Sub-module builds standalone:
+
+```sh
+cd modules/letsencrypt
+go build ./...
+go test ./...
+```
+
+If you have a `go.work` file in a parent directory (multi-repo workspace):
+
+```sh
+GOWORK=off go build ./...
+GOWORK=off go test ./...
+```
+
+## Pull requests
+
+- One feature or bugfix per PR. Keep changes scoped to this sub-module.
+- Update CHANGELOG.md (in this sub-module's directory) with a Keep-a-Changelog entry.
+- Add tests covering new behaviour — match this sub-module's existing test style.
+- Run `GOWORK=off go vet ./...` before pushing.
+- Bump the sub-module tag (`modules/letsencrypt/vN.M.P`) separately from the core `modular` tag.
+
+## Reporting issues
+
+Use the issue templates under `.github/ISSUE_TEMPLATE/` at the repo root.

--- a/modules/reverseproxy/CONTRIBUTING.md
+++ b/modules/reverseproxy/CONTRIBUTING.md
@@ -1,0 +1,36 @@
+# Contributing to modular/reverseproxy
+
+This is a sub-module of [GoCodeAlone/modular](https://github.com/GoCodeAlone/modular) — a separately-versioned Go module under `modules/reverseproxy/`. Its tag stream is `modules/reverseproxy/vN.M.P`, independent of the core `modular` package.
+
+## Before contributing
+
+Read the top-level [CONTRIBUTING.md](../../CONTRIBUTING.md) for general conventions.
+
+## Local development
+
+Sub-module builds standalone:
+
+```sh
+cd modules/reverseproxy
+go build ./...
+go test ./...
+```
+
+If you have a `go.work` file in a parent directory (multi-repo workspace):
+
+```sh
+GOWORK=off go build ./...
+GOWORK=off go test ./...
+```
+
+## Pull requests
+
+- One feature or bugfix per PR. Keep changes scoped to this sub-module.
+- Update CHANGELOG.md (in this sub-module's directory) with a Keep-a-Changelog entry.
+- Add tests covering new behaviour — match this sub-module's existing test style.
+- Run `GOWORK=off go vet ./...` before pushing.
+- Bump the sub-module tag (`modules/reverseproxy/vN.M.P`) separately from the core `modular` tag.
+
+## Reporting issues
+
+Use the issue templates under `.github/ISSUE_TEMPLATE/` at the repo root.


### PR DESCRIPTION
Follow-up to #110. Each modules/<name>/ sub-dir is separately versioned and gets its own CONTRIBUTING documenting tag stream + GOWORK=off pattern.