### PR TITLE
build(deps): bump codecov/codecov-action from 5.5.2 to 6.0.0

### DIFF
--- a/.github/workflows/bdd-matrix.yml
+++ b/.github/workflows/bdd-matrix.yml
@@ -64,7 +64,7 @@ jobs:
           export GORACE=halt_on_error=1
           go test -race -v -coverprofile=core-bdd-coverage.txt -covermode=atomic -run 'TestApplicationLifecycle|TestConfigurationManagement|TestBaseConfigBDDFeatures|TestLoggerDecorator' .
       - name: Upload core BDD coverage
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.0 pinned
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: GoCodeAlone/modular
@@ -124,7 +124,7 @@ jobs:
           fi
       - name: Upload module BDD coverage
         if: always()
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.0 pinned
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: GoCodeAlone/modular
@@ -200,7 +200,7 @@ jobs:
           echo "Merged (fallback) into $OUT from ${#FILES[@]} files" >&2
       - name: Upload merged BDD coverage
         if: always()
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.0 pinned
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: GoCodeAlone/modular

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
           go test -race ./... -v
           go test -race -v -coverprofile=coverage.txt -covermode=atomic -json ./... >> report.json
       - name: Upload coverage reports to Codecov (unit)
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.0 pinned
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: GoCodeAlone/modular
@@ -91,7 +91,7 @@ jobs:
           go test ./... -v -coverprofile=cli-coverage.txt -covermode=atomic -json >> cli-report.json
 
       - name: Upload CLI coverage reports to Codecov
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.0 pinned
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: GoCodeAlone/modular
@@ -189,7 +189,7 @@ jobs:
       - name: Upload merged total coverage
         # Fail the job if Codecov can't find or upload the merged coverage
         if: always()
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.0 pinned
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: GoCodeAlone/modular

--- a/.github/workflows/modules-ci.yml
+++ b/.github/workflows/modules-ci.yml
@@ -134,7 +134,7 @@ jobs:
   # BDD tests moved to dedicated module-bdd matrix job
 
       - name: Upload coverage for ${{ matrix.module }}
-        uses: codecov/codecov-action@671740ac38dd9b0130fbe1cec585b89eea48d3de # v5.5.0 pinned
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: GoCodeAlone/modular


### PR DESCRIPTION
Supersedes #97. Dependabot could not rebase #97 (its branch was hand-edited with a panic-wrap commit now on main). Clean re-apply on current main.

- Pins `codecov/codecov-action` to **v6.0.0** (`57e3a136b779b570ffcdbf80b3bdc90e7fab3de2`) across all 7 usages in ci.yml / bdd-matrix.yml / modules-ci.yml.
- Corrects the stale `# v5.5.0 pinned` comment — main's `671740ac` SHA was actually v5.5.2.

Closes #97.