### PR TITLE
security: add least-privilege permissions to release workflows

### DIFF
--- a/.github/workflows/module-release.yml
+++ b/.github/workflows/module-release.yml
@@ -44,9 +44,13 @@ on:
         required: true
         type: string
 
+permissions: {}
+
 jobs:
   prepare-release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read       # checkout repository to detect module changes and list modules
     outputs:
       modules: ${{ steps.get-modules.outputs.modules }}
     steps:
@@ -104,6 +108,9 @@ jobs:
     needs: prepare-release
     runs-on: ubuntu-latest
     if: needs.prepare-release.outputs.modules && needs.prepare-release.result == 'success'
+    permissions:
+      contents: write      # create GitHub release, push tags, push branch for module-path PR
+      pull-requests: write # create PR for module path update (v2+ scenario)
     steps:
       - name: Checkout code
         uses: actions/checkout@v6

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,9 +41,14 @@ on:
         description: 'Version tag produced by the release job'
         value: ${{ jobs.release.outputs.released_version }}
 
+permissions: {}
+
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write      # create GitHub release, upload release asset, push branch for module-path PR
+      pull-requests: write # create PR for module path update (v2+ scenario)
     outputs:
       released_version: ${{ steps.version.outputs.next_version }}
       core_changed: ${{ steps.detect.outputs.core_changed }}
@@ -440,6 +445,11 @@ jobs:
   bump-modules:
     needs: release
     if: needs.release.result == 'success' && needs.release.outputs.core_changed == 'true' && inputs.skipModuleBump != true
+    permissions:
+      contents: write      # callee (auto-bump-modules) commits, pushes branch, merges PR
+      pull-requests: write # callee creates and merges the bump PR
+      actions: read        # callee reads workflow run status
+      checks: write        # callee writes check results
     uses: ./.github/workflows/auto-bump-modules.yml
     with:
       coreVersion: ${{ needs.release.outputs.released_version }}


### PR DESCRIPTION
## Summary

Fixes CodeQL `actions/missing-workflow-permissions` MEDIUM alerts in two release workflows by adding a top-level `permissions: {}` deny-all default and explicit least-privilege `permissions:` blocks on each job.

No workflow logic was changed — only `permissions:` keys were added.

## Permissions added per job

### `release.yml`

**Top-level (new):**
```yaml
permissions: {}
```
Denies all scopes by default; jobs below grant only what they need.

**`release` job (was flagged ~line 46):**
```yaml
permissions:
  contents: write      # gh release create, upload asset, git push branch for module-path PR
  pull-requests: write # gh pr create for v2+ module-path update
```
Reasoning: the `Create release` step runs `gh release create … "$ARCHIVE"` (uploads asset → `contents: write`). The `Create PR for module path update` step runs `git push origin "$BRANCH_NAME"` and `gh pr create` → both need `contents: write` + `pull-requests: write`.

**`bump-modules` job (was flagged ~line 441):**
```yaml
permissions:
  contents: write      # callee commits, pushes branch, and merges PR
  pull-requests: write # callee creates and merges the bump PR
  actions: read        # callee reads workflow run status
  checks: write        # callee writes check results
```
Reasoning: `bump-modules` is a `uses:` delegation to `auto-bump-modules.yml`, which already declares these four scopes in its own top-level `permissions:` block. When a reusable workflow is called, the caller's GITHUB_TOKEN permissions bound what the callee receives — so the caller must carry at least the scopes the callee needs.

---

### `module-release.yml`

**Top-level (new):**
```yaml
permissions: {}
```

**`prepare-release` job (read-only prep):**
```yaml
permissions:
  contents: read       # checkout + git tag list + find modules directory
```
Reasoning: this job only reads the repo (checkout, `git tag -l`, `find modules`). No writes anywhere.

**`release-module` job (was flagged ~line 104):**
```yaml
permissions:
  contents: write      # gh release create, git push origin "$TAG", git push branch for module-path PR
  pull-requests: write # gh pr create for v2+ module-path update
```
Reasoning: the `Create release` step runs `gh release create` and then `git push origin "$TAG"` (tag push → `contents: write`). The `Create PR for module path update` step runs `git push origin "$BRANCH_NAME"` and `gh pr create` → `contents: write` + `pull-requests: write`.

## Test plan

- [ ] YAML validates cleanly (`python3 -c "import yaml; yaml.safe_load(open(f))"` passes for both files — confirmed locally before push)
- [ ] Trigger `Release` workflow (`workflow_dispatch`) on a patch bump and confirm the `release` job and `bump-modules` job both complete successfully
- [ ] Trigger `Module Release` workflow and confirm `prepare-release` + `release-module` both complete successfully
- [ ] Confirm CodeQL `actions/missing-workflow-permissions` alerts are resolved after the next scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)