### PR TITLE
security: add least-privilege permissions to Examples CI workflow

### DIFF
--- a/.github/workflows/examples-ci.yml
+++ b/.github/workflows/examples-ci.yml
@@ -11,6 +11,12 @@ on:
   # Allow manual trigger
   workflow_dispatch:
 
+# Least-privilege default: both jobs only check out and build/test the example
+# modules, so read access to repository contents is sufficient (CodeQL
+# actions/missing-workflow-permissions).
+permissions:
+  contents: read
+
 env:
   GO_VERSION: '^1.26'
 


### PR DESCRIPTION
Resolves the 2 remaining `actions/missing-workflow-permissions` CodeQL alerts (examples-ci.yml:19, :473).

Adds top-level `permissions: contents: read`. Both jobs (validate-examples, examples-overview) only check out + build/test example modules — read access is sufficient. Completes the workflow-permissions hardening started in #119.