### PR TITLE
Avoid lifecycle locks across callbacks

### DIFF
--- a/.github/workflows/examples-ci.yml
+++ b/.github/workflows/examples-ci.yml
@@ -11,6 +11,12 @@ on:
   # Allow manual trigger
   workflow_dispatch:
 
+# Least-privilege default: both jobs only check out and build/test the example
+# modules, so read access to repository contents is sufficient (CodeQL
+# actions/missing-workflow-permissions).
+permissions:
+  contents: read
+
 env:
   GO_VERSION: '^1.26'
 

--- a/scheduler/lifecycle_lock_test.go
+++ b/scheduler/lifecycle_lock_test.go
@@ -1,0 +1,103 @@
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/GoCodeAlone/modular"
+	"github.com/stretchr/testify/require"
+)
+
+type blockingPersistenceHandler struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+func newBlockingPersistenceHandler() *blockingPersistenceHandler {
+	return &blockingPersistenceHandler{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (h *blockingPersistenceHandler) Save([]Job) error {
+	select {
+	case <-h.entered:
+	default:
+		close(h.entered)
+	}
+	<-h.release
+	return nil
+}
+
+func (h *blockingPersistenceHandler) Load() ([]Job, error) {
+	return nil, nil
+}
+
+func TestSchedulerLifecyclePersistenceDoesNotStarveMetrics(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		call func(context.Context, *SchedulerModule) error
+	}{
+		{name: "Stop", call: func(ctx context.Context, module *SchedulerModule) error {
+			return module.Stop(ctx)
+		}},
+		{name: "PreStop", call: func(ctx context.Context, module *SchedulerModule) error {
+			return module.PreStop(ctx)
+		}},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			handler := newBlockingPersistenceHandler()
+			module := NewModule().(*SchedulerModule)
+			app := newMockApp()
+			config := &SchedulerConfig{
+				WorkerCount:        1,
+				QueueSize:          10,
+				StorageType:        "memory",
+				CheckInterval:      time.Hour,
+				ShutdownTimeout:    time.Second,
+				RetentionDays:      7,
+				PersistenceBackend: PersistenceBackendCustom,
+				PersistenceHandler: handler,
+			}
+			app.RegisterConfigSection(ModuleName, modular.NewStdConfigProvider(config))
+			require.NoError(t, module.Init(app))
+			require.NoError(t, module.Start(context.Background()))
+			_, err := module.ScheduleJob(Job{
+				Name:    "persist-later",
+				RunAt:   time.Now().Add(time.Hour),
+				JobFunc: func(context.Context) error { return nil },
+			})
+			require.NoError(t, err)
+
+			errCh := make(chan error, 1)
+			go func() {
+				errCh <- tc.call(context.Background(), module)
+			}()
+
+			select {
+			case <-handler.entered:
+			case <-time.After(time.Second):
+				close(handler.release)
+				t.Fatal("lifecycle call did not reach persistence handler")
+			}
+
+			metricsDone := make(chan struct{})
+			go func() {
+				_ = module.CollectMetrics(context.Background())
+				close(metricsDone)
+			}()
+
+			select {
+			case <-metricsDone:
+			case <-time.After(100 * time.Millisecond):
+				close(handler.release)
+				t.Fatal("CollectMetrics blocked behind lifecycle persistence")
+			}
+
+			close(handler.release)
+			require.NoError(t, <-errCh)
+		})
+	}
+}

--- a/scheduler/lifecycle_lock_test.go
+++ b/scheduler/lifecycle_lock_test.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -12,6 +13,7 @@ import (
 type blockingPersistenceHandler struct {
 	entered chan struct{}
 	release chan struct{}
+	saves   atomic.Int32
 }
 
 func newBlockingPersistenceHandler() *blockingPersistenceHandler {
@@ -22,6 +24,7 @@ func newBlockingPersistenceHandler() *blockingPersistenceHandler {
 }
 
 func (h *blockingPersistenceHandler) Save([]Job) error {
+	h.saves.Add(1)
 	select {
 	case <-h.entered:
 	default:
@@ -100,4 +103,62 @@ func TestSchedulerLifecyclePersistenceDoesNotStarveMetrics(t *testing.T) {
 			require.NoError(t, <-errCh)
 		})
 	}
+}
+
+func TestSchedulerStopClaimsShutdownBeforePersistence(t *testing.T) {
+	handler := newBlockingPersistenceHandler()
+	module := NewModule().(*SchedulerModule)
+	app := newMockApp()
+	config := &SchedulerConfig{
+		WorkerCount:        1,
+		QueueSize:          10,
+		StorageType:        "memory",
+		CheckInterval:      time.Hour,
+		ShutdownTimeout:    time.Second,
+		RetentionDays:      7,
+		PersistenceBackend: PersistenceBackendCustom,
+		PersistenceHandler: handler,
+	}
+	app.RegisterConfigSection(ModuleName, modular.NewStdConfigProvider(config))
+	require.NoError(t, module.Init(app))
+	require.NoError(t, module.Start(context.Background()))
+	_, err := module.ScheduleJob(Job{
+		Name:    "persist-later",
+		RunAt:   time.Now().Add(time.Hour),
+		JobFunc: func(context.Context) error { return nil },
+	})
+	require.NoError(t, err)
+
+	firstStop := make(chan error, 1)
+	go func() {
+		firstStop <- module.Stop(context.Background())
+	}()
+
+	select {
+	case <-handler.entered:
+	case <-time.After(time.Second):
+		close(handler.release)
+		t.Fatal("first Stop did not reach persistence handler")
+	}
+
+	secondStop := make(chan error, 1)
+	go func() {
+		secondStop <- module.Stop(context.Background())
+	}()
+
+	select {
+	case err := <-secondStop:
+		require.NoError(t, err)
+	case <-time.After(100 * time.Millisecond):
+		close(handler.release)
+		t.Fatal("second Stop blocked behind first Stop persistence")
+	}
+
+	if saves := handler.saves.Load(); saves != 1 {
+		close(handler.release)
+		t.Fatalf("expected one persistence save before release, got %d", saves)
+	}
+
+	close(handler.release)
+	require.NoError(t, <-firstStop)
 }

--- a/scheduler/module.go
+++ b/scheduler/module.go
@@ -256,6 +256,7 @@ func (m *SchedulerModule) Stop(ctx context.Context) error {
 		m.schedulerLock.Unlock()
 		return nil
 	}
+	m.running = false
 	m.schedulerLock.Unlock()
 
 	// Create a context with timeout for graceful shutdown
@@ -286,10 +287,6 @@ func (m *SchedulerModule) Stop(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-
-	m.schedulerLock.Lock()
-	m.running = false
-	m.schedulerLock.Unlock()
 
 	// Emit module stopped event
 	m.emitEvent(ctx, EventTypeModuleStopped, map[string]interface{}{

--- a/scheduler/module.go
+++ b/scheduler/module.go
@@ -252,11 +252,11 @@ func (m *SchedulerModule) Stop(ctx context.Context) error {
 	m.logger.Info("Stopping scheduler module")
 
 	m.schedulerLock.Lock()
-	defer m.schedulerLock.Unlock()
-
 	if !m.running {
+		m.schedulerLock.Unlock()
 		return nil
 	}
+	m.schedulerLock.Unlock()
 
 	// Create a context with timeout for graceful shutdown
 	shutdownCtx, cancel := context.WithTimeout(ctx, m.config.ShutdownTimeout)
@@ -287,7 +287,9 @@ func (m *SchedulerModule) Stop(ctx context.Context) error {
 		return err
 	}
 
+	m.schedulerLock.Lock()
 	m.running = false
+	m.schedulerLock.Unlock()
 
 	// Emit module stopped event
 	m.emitEvent(ctx, EventTypeModuleStopped, map[string]interface{}{
@@ -609,14 +611,16 @@ func (m *SchedulerModule) CollectMetrics(ctx context.Context) modular.ModuleMetr
 // dispatching new jobs. Actual worker shutdown happens in Stop().
 func (m *SchedulerModule) PreStop(ctx context.Context) error {
 	m.schedulerLock.Lock()
-	defer m.schedulerLock.Unlock()
+	scheduler := m.scheduler
+	config := m.config
+	m.schedulerLock.Unlock()
 
 	if m.logger != nil {
 		m.logger.Info("Scheduler drain phase starting")
 	}
 
 	// Save jobs if persistence is enabled
-	if m.config != nil && m.config.PersistenceBackend != PersistenceBackendNone {
+	if config != nil && config.PersistenceBackend != PersistenceBackendNone {
 		if err := m.savePersistedJobs(); err != nil {
 			if m.logger != nil {
 				m.logger.Warn("PreStop: failed to save jobs", "error", err)
@@ -626,8 +630,8 @@ func (m *SchedulerModule) PreStop(ctx context.Context) error {
 
 	// Stop dispatching new jobs by cancelling the scheduler's context.
 	// Workers will finish in-flight jobs; Stop() handles the full shutdown.
-	if m.scheduler != nil && m.scheduler.cancel != nil {
-		m.scheduler.cancel()
+	if scheduler != nil && scheduler.cancel != nil {
+		scheduler.cancel()
 	}
 
 	return nil

--- a/tenant_service.go
+++ b/tenant_service.go
@@ -209,7 +209,6 @@ func (ts *StandardTenantService) RegisterTenantConfigSection(
 	provider ConfigProvider,
 ) error {
 	ts.mutex.Lock()
-	defer ts.mutex.Unlock()
 
 	tenantCfg, exists := ts.tenantConfigs[tenantID]
 	if !exists {

--- a/tenant_service.go
+++ b/tenant_service.go
@@ -18,6 +18,11 @@ type StandardTenantService struct {
 	moduleNotifications map[TenantAwareModule]map[TenantID]bool
 }
 
+type tenantModuleNotification struct {
+	module   TenantAwareModule
+	tenantID TenantID
+}
+
 // NewStandardTenantService creates a new tenant service
 func NewStandardTenantService(logger Logger) *StandardTenantService {
 	return &StandardTenantService{
@@ -63,7 +68,6 @@ func (ts *StandardTenantService) GetTenants() []TenantID {
 // RegisterTenant registers a new tenant with optional initial configs
 func (ts *StandardTenantService) RegisterTenant(tenantID TenantID, configs map[string]ConfigProvider) error {
 	ts.mutex.Lock()
-	defer ts.mutex.Unlock()
 
 	// Check if tenant already exists and update existing configs instead of returning an error
 	if existingConfig, exists := ts.tenantConfigs[tenantID]; exists {
@@ -80,6 +84,7 @@ func (ts *StandardTenantService) RegisterTenant(tenantID TenantID, configs map[s
 				existingConfig.SetTenantConfig(tenantID, section, provider)
 			}
 		}
+		ts.mutex.Unlock()
 		return nil
 	}
 
@@ -104,57 +109,68 @@ func (ts *StandardTenantService) RegisterTenant(tenantID TenantID, configs map[s
 
 	ts.logger.Info("Registered tenant", "tenantID", tenantID)
 
-	// Notify tenant-aware modules
-	for _, module := range ts.tenantAwareModules {
-		ts.notifyModuleAboutTenant(module, tenantID)
-	}
+	notifications := ts.prepareTenantNotificationsLocked(tenantID, ts.tenantAwareModules)
+	ts.mutex.Unlock()
+	ts.notifyModulesAboutTenants(notifications, "Notified module about tenant")
 
 	return nil
 }
 
-// notifyModuleAboutTenant safely notifies a module about a tenant if it hasn't been notified before
-func (ts *StandardTenantService) notifyModuleAboutTenant(module TenantAwareModule, tenantID TenantID) {
-	// Initialize the notification map for this module if it doesn't exist
-	if _, exists := ts.moduleNotifications[module]; !exists {
-		ts.moduleNotifications[module] = make(map[TenantID]bool)
+// prepareTenantNotificationsLocked records pending tenant notifications while ts.mutex is held.
+func (ts *StandardTenantService) prepareTenantNotificationsLocked(
+	tenantID TenantID,
+	modules []TenantAwareModule,
+) []tenantModuleNotification {
+	notifications := make([]tenantModuleNotification, 0, len(modules))
+	for _, module := range modules {
+		if _, exists := ts.moduleNotifications[module]; !exists {
+			ts.moduleNotifications[module] = make(map[TenantID]bool)
+		}
+		if ts.moduleNotifications[module][tenantID] {
+			ts.logger.Debug("Module already notified about tenant",
+				"module", fmt.Sprintf("%T", module), "tenantID", tenantID)
+			continue
+		}
+		ts.moduleNotifications[module][tenantID] = true
+		notifications = append(notifications, tenantModuleNotification{module: module, tenantID: tenantID})
 	}
+	return notifications
+}
 
-	// Check if this module has already been notified about this tenant
-	if ts.moduleNotifications[module][tenantID] {
-		ts.logger.Debug("Module already notified about tenant",
-			"module", fmt.Sprintf("%T", module), "tenantID", tenantID)
-		return
+func (ts *StandardTenantService) notifyModulesAboutTenants(notifications []tenantModuleNotification, message string) {
+	for _, notification := range notifications {
+		notification.module.OnTenantRegistered(notification.tenantID)
+		ts.logger.Debug(message,
+			"module", fmt.Sprintf("%T", notification.module), "tenantID", notification.tenantID)
 	}
-
-	// Notify the module and mark it as notified
-	module.OnTenantRegistered(tenantID)
-	ts.moduleNotifications[module][tenantID] = true
-	ts.logger.Debug("Notified module about tenant",
-		"module", fmt.Sprintf("%T", module), "tenantID", tenantID)
 }
 
 // RemoveTenant removes a tenant and its configurations
 func (ts *StandardTenantService) RemoveTenant(tenantID TenantID) error {
 	ts.mutex.Lock()
-	defer ts.mutex.Unlock()
 
 	if _, exists := ts.tenantConfigs[tenantID]; !exists {
+		ts.mutex.Unlock()
 		return fmt.Errorf("%w: %s", ErrTenantNotFound, tenantID)
 	}
 
 	delete(ts.tenantConfigs, tenantID)
 	ts.logger.Info("Removed tenant", "tenantID", tenantID)
 
-	// Notify tenant-aware modules
+	notifications := make([]tenantModuleNotification, 0, len(ts.tenantAwareModules))
 	for _, module := range ts.tenantAwareModules {
-		module.OnTenantRemoved(tenantID)
-		ts.logger.Debug("Notified module about tenant removal",
-			"module", fmt.Sprintf("%T", module), "tenantID", tenantID)
-
-		// Also remove this tenant from the notification tracking
 		if notifications, exists := ts.moduleNotifications[module]; exists {
 			delete(notifications, tenantID)
 		}
+		notifications = append(notifications, tenantModuleNotification{module: module, tenantID: tenantID})
+	}
+	ts.mutex.Unlock()
+
+	// Notify tenant-aware modules outside the service mutex.
+	for _, notification := range notifications {
+		notification.module.OnTenantRemoved(notification.tenantID)
+		ts.logger.Debug("Notified module about tenant removal",
+			"module", fmt.Sprintf("%T", notification.module), "tenantID", notification.tenantID)
 	}
 
 	return nil
@@ -163,12 +179,12 @@ func (ts *StandardTenantService) RemoveTenant(tenantID TenantID) error {
 // RegisterTenantAwareModule registers a module to receive tenant events
 func (ts *StandardTenantService) RegisterTenantAwareModule(module TenantAwareModule) error {
 	ts.mutex.Lock()
-	defer ts.mutex.Unlock()
 
 	// Check if the module is already registered to avoid duplicates
 	if slices.Contains(ts.tenantAwareModules, module) {
 		ts.logger.Debug("Module already registered as tenant-aware",
 			"module", fmt.Sprintf("%T", module), "name", module.Name())
+		ts.mutex.Unlock()
 		return nil
 	}
 
@@ -177,9 +193,12 @@ func (ts *StandardTenantService) RegisterTenantAwareModule(module TenantAwareMod
 		"module", fmt.Sprintf("%T", module), "name", module.Name())
 
 	// Notify about existing tenants
+	notifications := make([]tenantModuleNotification, 0, len(ts.tenantConfigs))
 	for tenantID := range ts.tenantConfigs {
-		ts.notifyModuleAboutTenant(module, tenantID)
+		notifications = append(notifications, ts.prepareTenantNotificationsLocked(tenantID, []TenantAwareModule{module})...)
 	}
+	ts.mutex.Unlock()
+	ts.notifyModulesAboutTenants(notifications, "Notified module about tenant")
 	return nil
 }
 
@@ -198,19 +217,21 @@ func (ts *StandardTenantService) RegisterTenantConfigSection(
 		tenantCfg = NewTenantConfigProvider(nil)
 		ts.tenantConfigs[tenantID] = tenantCfg
 		ts.logger.Info("Created new tenant during config section registration", "tenantID", tenantID)
-
-		// Notify modules of the new tenant
-		for _, module := range ts.tenantAwareModules {
-			ts.notifyModuleAboutTenant(module, tenantID)
-		}
 	}
 
 	if provider == nil || provider.GetConfig() == nil {
+		ts.mutex.Unlock()
 		return fmt.Errorf("%w: section '%s' for tenant %s", ErrTenantRegisterNilConfig, section, tenantID)
 	}
 
 	tenantCfg.SetTenantConfig(tenantID, section, provider)
 	ts.logger.Info("Registered tenant config section", "tenantID", tenantID, "section", section)
+	notifications := []tenantModuleNotification(nil)
+	if !exists {
+		notifications = ts.prepareTenantNotificationsLocked(tenantID, ts.tenantAwareModules)
+	}
+	ts.mutex.Unlock()
+	ts.notifyModulesAboutTenants(notifications, "Notified module about tenant")
 	return nil
 }
 

--- a/tenant_service_lock_test.go
+++ b/tenant_service_lock_test.go
@@ -1,0 +1,115 @@
+package modular
+
+import (
+	"context"
+	"log/slog"
+	"testing"
+	"time"
+)
+
+type blockingTenantAwareModule struct {
+	entered chan struct{}
+	release chan struct{}
+}
+
+func newBlockingTenantAwareModule() *blockingTenantAwareModule {
+	return &blockingTenantAwareModule{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+	}
+}
+
+func (m *blockingTenantAwareModule) Name() string                          { return "blockingTenantAwareModule" }
+func (m *blockingTenantAwareModule) Init(Application) error                { return nil }
+func (m *blockingTenantAwareModule) Start(context.Context) error           { return nil }
+func (m *blockingTenantAwareModule) Stop(context.Context) error            { return nil }
+func (m *blockingTenantAwareModule) Dependencies() []string                { return nil }
+func (m *blockingTenantAwareModule) ProvidesServices() []ServiceProvider   { return nil }
+func (m *blockingTenantAwareModule) RequiresServices() []ServiceDependency { return nil }
+func (m *blockingTenantAwareModule) RegisterConfig(Application)            {}
+
+func (m *blockingTenantAwareModule) OnTenantRegistered(TenantID) {
+	m.block()
+}
+
+func (m *blockingTenantAwareModule) OnTenantRemoved(TenantID) {
+	m.block()
+}
+
+func (m *blockingTenantAwareModule) block() {
+	select {
+	case <-m.entered:
+	default:
+		close(m.entered)
+	}
+	<-m.release
+}
+
+func TestTenantLifecycleCallbacksDoNotStarveTenantReaders(t *testing.T) {
+	for _, tc := range []struct {
+		name     string
+		call     func(*StandardTenantService, TenantID) error
+		readable TenantID
+	}{
+		{
+			name: "RegisterTenant",
+			call: func(ts *StandardTenantService, tenantID TenantID) error {
+				return ts.RegisterTenant(tenantID, map[string]ConfigProvider{
+					"app": NewStdConfigProvider(&struct{ Enabled bool }{Enabled: true}),
+				})
+			},
+			readable: TenantID("tenant-under-registration"),
+		},
+		{
+			name: "RemoveTenant",
+			call: func(ts *StandardTenantService, tenantID TenantID) error {
+				return ts.RemoveTenant(tenantID)
+			},
+			readable: TenantID("existing-tenant"),
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ts := NewStandardTenantService(slog.Default())
+			module := newBlockingTenantAwareModule()
+			if err := ts.RegisterTenantAwareModule(module); err != nil {
+				t.Fatalf("register module: %v", err)
+			}
+			if tc.name == "RemoveTenant" {
+				tenantCfg := NewTenantConfigProvider(nil)
+				tenantCfg.SetTenantConfig(TenantID("existing-tenant"), "app", NewStdConfigProvider(&struct{ Enabled bool }{Enabled: true}))
+				ts.tenantConfigs[TenantID("existing-tenant")] = tenantCfg
+				ts.moduleNotifications[module] = map[TenantID]bool{TenantID("existing-tenant"): true}
+			}
+
+			errCh := make(chan error, 1)
+			go func() {
+				errCh <- tc.call(ts, tc.readable)
+			}()
+
+			select {
+			case <-module.entered:
+			case <-time.After(time.Second):
+				close(module.release)
+				t.Fatal("lifecycle call did not reach tenant-aware callback")
+			}
+
+			readDone := make(chan struct{})
+			go func() {
+				_, _ = ts.GetTenantConfig(tc.readable, "app")
+				close(readDone)
+			}()
+
+			select {
+			case <-readDone:
+			case <-time.After(100 * time.Millisecond):
+				close(module.release)
+				t.Fatal("tenant config read blocked behind tenant-aware callback")
+			}
+
+			close(module.release)
+			if err := <-errCh; err != nil {
+				t.Fatalf("lifecycle call: %v", err)
+			}
+		})
+	}
+}

--- a/tenant_service_lock_test.go
+++ b/tenant_service_lock_test.go
@@ -2,6 +2,7 @@ package modular
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"testing"
 	"time"
@@ -111,5 +112,26 @@ func TestTenantLifecycleCallbacksDoNotStarveTenantReaders(t *testing.T) {
 				t.Fatalf("lifecycle call: %v", err)
 			}
 		})
+	}
+}
+
+func TestRegisterTenantConfigSectionRejectsNilProviderWithoutUnlockPanic(t *testing.T) {
+	ts := NewStandardTenantService(slog.Default())
+
+	err := ts.RegisterTenantConfigSection(TenantID("tenant-a"), "app", nil)
+	if !errors.Is(err, ErrTenantRegisterNilConfig) {
+		t.Fatalf("expected ErrTenantRegisterNilConfig, got %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = ts.GetTenantConfig(TenantID("tenant-a"), "app")
+		close(done)
+	}()
+
+	select {
+	case <-done:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("tenant service mutex remained locked after nil provider error")
 	}
 }


### PR DESCRIPTION
## Summary
- release scheduler lifecycle lock before persistence saves in Stop/PreStop
- release tenant service lock before TenantAwareModule callbacks
- add starvation regression tests for scheduler metrics and tenant reads

## Verification
- go test ./...
- go test -race ./scheduler ./... -run 'TestSchedulerLifecyclePersistenceDoesNotStarveMetrics|TestTenantLifecycleCallbacksDoNotStarveTenantReaders' -count=1
- revert proof: focused regression tests fail when the old lock-across-I/O/callback behavior is restored

## Downstream impact
No public API change. This is a behavior fix for all direct modular consumers listed in the workspace portfolio, including workflow and most workflow-plugin-* repositories. After merge, release modular before bumping direct consumers that need the fix pinned.

Refs GoCodeAlone/workspace#133
